### PR TITLE
Update smrr.ttl

### DIFF
--- a/vocabs/smrr.ttl
+++ b/vocabs/smrr.ttl
@@ -85,7 +85,8 @@ cs:
     skos:definition "The roles that resources plan in BDR Submission Manifests"@en ;
     skos:historyNote "This vocabulary was developed to assist with the processing of data submissions to the Biodiversity Data Repository in February 2025" ;
     skos:prefLabel "BDR Submission Manifest Resource Roles"@en ;
-    skos:scopeNote "See the ABIS Specification, <https://linked.data.gov.au/def/abis> - BDR Profile Section, for the definition of BDR Submission Manifests"@en ;
+    skos:scopeNote "See the BDR Profile of ABIS - C.3.2 Submission Manifest, for the definition of Submission Manifest"@en ;
+    schema:citation "https://dcceew-bdr.github.io/bdr-profile-of-abis/specification.html#sm:SubmissionManifest"^^xsd:anyURI ;
     schema:creator <https://linked.data.gov.au/org/dcceew> ;
     schema:dateCreated "2025-02-10"^^xsd:date ;
     schema:dateModified "2025-02-10"^^xsd:date ;

--- a/vocabs/smrr.ttl
+++ b/vocabs/smrr.ttl
@@ -89,7 +89,7 @@ cs:
     schema:citation "https://dcceew-bdr.github.io/bdr-profile-of-abis/specification.html#sm:SubmissionManifest"^^xsd:anyURI ;
     schema:creator <https://linked.data.gov.au/org/dcceew> ;
     schema:dateCreated "2025-02-10"^^xsd:date ;
-    schema:dateModified "2025-02-10"^^xsd:date ;
+    schema:dateModified "2026-03-11"^^xsd:date ;
     schema:license <http://purl.org/NET/rdflicense/cc-by4.0> ;
     schema:publisher <https://linked.data.gov.au/org/dcceew> ;
     skos:hasTopConcept 


### PR DESCRIPTION
The definition for submission manifests appears to have migrated from ABIS ==> BRR profile of ABIS. I've updated the skos:scopeNote and added a schema:citation to the anchor link there. Minimal fix - we could go further, linking this cs: to the model IRI <https://linked.data.gov.au/def/bdr-pr/sm> with some predicate.